### PR TITLE
Casing and word order

### DIFF
--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -90,7 +90,7 @@ class TextHighlight extends StatelessWidget {
         boundText = boundText.replaceAll(
             word, '|${words.keys.toList().indexOf(word)}|');
       } else {
-        for (int i = 0; i < word.allMatches(text.toLowerCase()).length; i++) {
+        for (int i = 0; i < word.toLowerCase().allMatches(text.toLowerCase()).length; i++) {
           int strIndex = boundText.toLowerCase().indexOf(word.toLowerCase());
           if (strIndex >= 0) {
             originalWords[word]!

--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -83,7 +83,10 @@ class TextHighlight extends StatelessWidget {
   String _multipleBinding() {
     String boundText = text;
 
-    for (String word in words.keys) {
+    List<String> wordList = words.keys.toList();
+    wordList.sort((String w1, String w2) => w2.length.compareTo(w1.length));
+
+    for (String word in wordList) {
       originalWords.addAll({word: <String>[]});
 
       if (matchCase) {

--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -82,47 +82,25 @@ class TextHighlight extends StatelessWidget {
 
   String _multipleBinding() {
     String boundText = text;
-    final Map<int, Match> allMatchesByStartIndex = <int, Match>{};
 
     for (String word in words.keys) {
-      originalWords[word] = <String>[];
+      originalWords.addAll({word: <String>[]});
 
-      Iterable<Match> wordMatches = matchCase
-          ? word.allMatches(text)
-          : word.toLowerCase().allMatches(text.toLowerCase())
-      ;
+      if (matchCase) {
+        boundText = boundText.replaceAll(
+            word, '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+      } else {
+        for (int i = 0; i < word.allMatches(text.toLowerCase()).length; i++) {
+          int strIndex = boundText.toLowerCase().indexOf(word.toLowerCase());
+          if (strIndex >= 0) {
+            originalWords[word]!
+                .add(boundText.substring(strIndex, strIndex + word.length));
 
-      for (Match match in wordMatches) {
-        if (match[0] != null) {
-          // If a match with the same start as the current match is already
-          // known, but the current match is longer, replace the known match.
-          // Otherwise do nothing, because otherwise this would
-          // attempt to highlight a subword in an already highlighted word,
-          // which would break the <highlight> syntax.
-          Match? knownMatch = allMatchesByStartIndex[match.start];
-          if (knownMatch == null || match[0]!.length > knownMatch[0]!.length) {
-            originalWords[word]!.add(text.substring(match.start, match.end));
-            allMatchesByStartIndex[match.start] = match;
+            boundText = boundText.replaceRange(strIndex, strIndex + word.length,
+                '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
           }
         }
       }
-    }
-
-    final List<String> sourceWords = matchCase
-        ? words.keys.toList()
-        : words.keys.map((w) => w.toLowerCase()).toList()
-    ;
-
-    // sort by start descending to replace from right to left
-    final List<Match> allMatches = allMatchesByStartIndex.values.toList();
-    allMatches.sort((m1, m2) => m2.start.compareTo(m1.start));
-
-    for (Match match in allMatches) {
-      boundText = boundText.replaceRange(
-        match.start,
-        match.end,
-        '<highlight>${sourceWords.indexOf(match[0]!)}<highlight>',
-      );
     }
 
     return boundText;

--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -88,7 +88,7 @@ class TextHighlight extends StatelessWidget {
 
       if (matchCase) {
         boundText = boundText.replaceAll(
-            word, '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+            word, '|${words.keys.toList().indexOf(word)}|');
       } else {
         for (int i = 0; i < word.allMatches(text.toLowerCase()).length; i++) {
           int strIndex = boundText.toLowerCase().indexOf(word.toLowerCase());
@@ -97,7 +97,7 @@ class TextHighlight extends StatelessWidget {
                 .add(boundText.substring(strIndex, strIndex + word.length));
 
             boundText = boundText.replaceRange(strIndex, strIndex + word.length,
-                '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+                '|${words.keys.toList().indexOf(word)}|');
           }
         }
       }
@@ -116,7 +116,7 @@ class TextHighlight extends StatelessWidget {
         int strIndex = boundText.indexOf(word);
         int strLastIndex = strIndex + word.length;
         boundText = boundText.replaceRange(strIndex, strLastIndex,
-            '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+            '|${words.keys.toList().indexOf(word)}|');
       } else {
         int strIndex = boundText.toLowerCase().indexOf(word.toLowerCase());
         int strLastIndex = strIndex + word.length;
@@ -125,7 +125,7 @@ class TextHighlight extends StatelessWidget {
               .add(boundText.substring(strIndex, strIndex + word.length));
 
           boundText = boundText.replaceRange(strIndex, strLastIndex,
-              '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+              '|${words.keys.toList().indexOf(word)}|');
         }
       }
     }
@@ -143,7 +143,7 @@ class TextHighlight extends StatelessWidget {
         int strIndex = boundText.lastIndexOf(word);
         int strLastIndex = strIndex + word.length;
         boundText = boundText.replaceRange(strIndex, strLastIndex,
-            '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+            '|${words.keys.toList().indexOf(word)}|');
       } else {
         int strIndex = boundText.toLowerCase().lastIndexOf(word.toLowerCase());
         int strLastIndex = strIndex + word.length;
@@ -152,7 +152,7 @@ class TextHighlight extends StatelessWidget {
               .add(boundText.substring(strIndex, strIndex + word.length));
 
           boundText = boundText.replaceRange(strIndex, strLastIndex,
-              '<highlight>${words.keys.toList().indexOf(word)}<highlight>');
+              '|${words.keys.toList().indexOf(word)}|');
         }
       }
     }
@@ -175,7 +175,7 @@ class TextHighlight extends StatelessWidget {
         boundWords = _multipleBinding();
     }
 
-    List<String> splitTexts = boundWords.split("<highlight>");
+    List<String> splitTexts = boundWords.split("|");
     splitTexts.removeWhere((s) => s.isEmpty);
 
     return splitTexts;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: highlight_text
 description: With this package you can highlight words and create specific styles and actions.
-version: 1.4.1
+version: 1.4.2
 homepage: https://github.com/desconexo/highlight_text
 
 environment:


### PR DESCRIPTION
* replace `<highlight>` with `|` to avoid issues with words which overlap with the word "highlight"
* highlight words from longest to shortest, because otherwise the longer word might not get highlighted if the shorter word is a subword of it