### PR TITLE
Explicitly setting textScaleFactor = 1.0 on child Text widget, so tha…

### DIFF
--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -260,6 +260,7 @@ class TextHighlight extends StatelessWidget {
                     child: Text(
                       w,
                       style: words[currentWord]!.textStyle ?? textStyle,
+                      textScaleFactor: 1.0,
                     ),
                   ),
                 ),


### PR DESCRIPTION
…t when "MediaQuery.of(context).textScaleFactor" != 1.0 the child components still render at the correct scale.

Parent textScaleFactor @ 0.85, unset in hightlight_text:
![highlight_text textScaleFactor 0 85](https://user-images.githubusercontent.com/121353776/209446232-1fd479f9-279a-41cf-a9c1-bfc86c1a843d.png)

Parent textScaleFactor @ 0.85, explicitly set to 1.0 in hightlight_text child Text widget:
![highlight_text textScaleFactor 1 0](https://user-images.githubusercontent.com/121353776/209446231-3fda4498-b46d-461a-af69-1aada150bcac.png)
