### PR TITLE
refactor build span logic

### DIFF
--- a/lib/highlight_text.dart
+++ b/lib/highlight_text.dart
@@ -221,73 +221,62 @@ class TextHighlight extends StatelessWidget {
   }
 
   TextSpan _buildSpan(List<String> boundWords) {
-    if (boundWords.isEmpty) return TextSpan();
-
-    String nextToDisplay = boundWords.first;
-    boundWords.removeAt(0);
-
-    int? index = int.tryParse(nextToDisplay);
-
-    if (index != null) {
-      try {
-        String currentWord = words.keys.toList()[index];
-        String showWord;
-        if (matchCase) {
-          showWord = currentWord;
-        } else {
-          showWord = _originalWords[currentWord]!.first;
-          _originalWords[currentWord]!.removeAt(0);
-        }
-        final List<String> splittedWords = [];
-        if (splitOnLongWord && showWord.contains(" ")) {
-          for (String w in showWord.split(" ")) {
-            splittedWords.addAll([w, " "]);
-          }
-        } else {
-          splittedWords.add(showWord);
-        }
-
-        return TextSpan(
-          children: [
-            for (String w in splittedWords)
-              if (w == " ")
-                _buildSpan([" "])
-              else
-                WidgetSpan(
-                  alignment: spanAlignment,
-                  child: GestureDetector(
-                    onTap: words[currentWord]!.onTap,
-                    child: Container(
-                      padding: words[currentWord]!.padding,
-                      decoration: words[currentWord]!.decoration,
-                      child: Text(
-                        w,
-                        style: words[currentWord]!.textStyle ?? textStyle,
-                        textScaleFactor: 1.0,
+    return TextSpan(
+      children: boundWords
+          .map<List<InlineSpan>>((word) {
+            final index = int.tryParse(word);
+            if (index != null) {
+              try {
+                String currentWord = words.keys.toList()[index];
+                String showWord;
+                if (matchCase) {
+                  showWord = currentWord;
+                } else {
+                  showWord = _originalWords[currentWord]!.first;
+                  _originalWords[currentWord]!.removeAt(0);
+                }
+                final List<String> splittedWords = [];
+                if (splitOnLongWord && showWord.contains(" ")) {
+                  for (String w in showWord.split(" ")) {
+                    splittedWords.addAll([w, " "]);
+                  }
+                } else {
+                  splittedWords.add(showWord);
+                }
+                return splittedWords.map((w) {
+                  if (w == ' ') {
+                    return TextSpan(
+                      text: '',
+                      style: textStyle,
+                    );
+                  }
+                  return WidgetSpan(
+                    alignment: spanAlignment,
+                    child: GestureDetector(
+                      onTap: words[currentWord]!.onTap,
+                      child: Container(
+                        padding: words[currentWord]!.padding,
+                        decoration: words[currentWord]!.decoration,
+                        child: Text(
+                          w,
+                          style: words[currentWord]!.textStyle ?? textStyle,
+                          textScaleFactor: 1.0,
+                        ),
                       ),
                     ),
-                  ),
-                ),
-            _buildSpan(boundWords),
-          ],
-        );
-      } catch (e) {
-        return TextSpan(
-          text: nextToDisplay,
-          style: textStyle,
-          children: [
-            _buildSpan(boundWords),
-          ],
-        );
-      }
-    }
-
-    return TextSpan(
-      text: nextToDisplay,
-      style: textStyle,
-      children: [
-        _buildSpan(boundWords),
-      ],
+                  );
+                }).toList();
+              } catch (e) {}
+            }
+            return [
+              TextSpan(
+                text: word,
+                style: textStyle,
+              )
+            ];
+          })
+          .expand((span) => span)
+          .toList(),
     );
   }
 }


### PR DESCRIPTION
This is a refactor of the current build span logic.
If this is merged, the next step will be rewriting the `_bind()` method.
My goal is by making the `_bind()` method returns a List of `String` and `int` values,
then we can tell if it's an `int`, it is a word that should be highlighted.
No more `int.tryParse()` in the `_buildSpan()` method, so that users can pass any text into this plugin, including the `|` character and numbers.

But I might not be smart enough to fully understand the original implementation, so you may want to check it carefully.