### PR TITLE
fix: prevent performance degradation with empty search queries

### DIFF
--- a/lib/src/highlight_text.dart
+++ b/lib/src/highlight_text.dart
@@ -66,7 +66,7 @@ class TextHighlight extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final sortedWords = sortWords(words.entries.toList());
+    final sortedWords = sortAndFilterWords(words.entries.toList());
     final boundWords = _bind(
       sortedWords.map((entry) => entry.key).toList(),
     );

--- a/lib/src/sort.dart
+++ b/lib/src/sort.dart
@@ -2,10 +2,12 @@ import 'highlighted_word.dart';
 
 // sort words by length,
 // so that we process longer words first in binding
-List<MapEntry<String, HighlightedWord>> sortWords(
+// empty words are removed to prevent infinite loops
+List<MapEntry<String, HighlightedWord>> sortAndFilterWords(
     List<MapEntry<String, HighlightedWord>> words) {
   return words
     ..sort(
       (a, b) => b.key.length.compareTo(a.key.length),
-    );
+    )
+    ..removeWhere((entry) => entry.key.trim().isEmpty);
 }

--- a/test/highlight_text_test.dart
+++ b/test/highlight_text_test.dart
@@ -45,11 +45,14 @@ void main() {
   });
 
   test('sortWords', () {
-    final sorted = sortWords({
+    final sorted = sortAndFilterWords({
       'apple': HighlightedWord(),
       'orange': HighlightedWord(),
       'pineapple': HighlightedWord(),
+      '': HighlightedWord(),
+      ' ': HighlightedWord(),
     }.entries.toList());
+    expect(sorted.length, 3);
     expect(
       sorted.map((entry) => entry.key).toList(),
       ['pineapple', 'orange', 'apple'],


### PR DESCRIPTION
This commit addresses a critical performance issue where empty or
whitespace-only search queries in the TextHighlight widget were causing
*excessive* creation of MatchedElement instances. The fix includes:

- Rewriting the sort function to sortAndFilter
- Filtering out map entries with empty keys or keys that become empty when trimmed
- Implementing this filter at the earliest possible stage to prevent downstream issues

*Performance improvements*:
- Significantly reduced memory usage and processing time for empty or invalid queries
- Improved overall efficiency by eliminating unnecessary computations

Also includes additional unit tests to prevent regression and ensure
proper handling of edge cases.

Fixes #51 